### PR TITLE
Added Slingshot

### DIFF
--- a/Assets/Prefab/Player.prefab
+++ b/Assets/Prefab/Player.prefab
@@ -2980,6 +2980,9 @@ MonoBehaviour:
   grappleIndicatorPrefab: {fileID: 6140398287122407268, guid: c235a6176978a1541a238729dbf6f4e2, type: 3}
   maximumWindUp: 10
   slingForce: 4
+  slingForwardBoost: 0.5
+  slingUpwardBoost: 0.1
+  slingMinYDir: 0.7
 --- !u!114 &6159800898551102946
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefab/Player.prefab
+++ b/Assets/Prefab/Player.prefab
@@ -252,13 +252,13 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1045017295403852707}
   serializedVersion: 2
-  m_LocalRotation: {x: -0.21643952, y: 0, z: 0, w: 0.97629607}
-  m_LocalPosition: {x: -0.18499994, y: -0.037, z: 0.16099977}
-  m_LocalScale: {x: 0.12787864, y: 0.1334799, z: 0.45924842}
+  m_LocalRotation: {x: -0.25447425, y: -0, z: -0, w: 0.9670796}
+  m_LocalPosition: {x: -0.18499994, y: -0.056, z: -0.052}
+  m_LocalScale: {x: 0.12787864, y: 0.13347991, z: 0.45924848}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 8404091402685267297}
-  m_Father: {fileID: 2028740325759082492}
+  m_Father: {fileID: 677107268057318285}
   m_LocalEulerAnglesHint: {x: -25, y: 0, z: 0}
 --- !u!33 &7975024567014387290
 MeshFilter:
@@ -1148,7 +1148,7 @@ Transform:
   m_GameObject: {fileID: 2614453586722883740}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0.5, y: 1.2, z: -5}
+  m_LocalPosition: {x: 0.5, y: 1.2, z: -5.0000005}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -1568,6 +1568,8 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
+  - {fileID: 3563727518308132522}
+  - {fileID: 8899145108802118775}
   - {fileID: 4755193659365559529}
   - {fileID: 2113288431984929346}
   - {fileID: 455870168519659391}
@@ -1727,13 +1729,13 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4914217257082264802}
   serializedVersion: 2
-  m_LocalRotation: {x: -0.21643952, y: 0, z: 0, w: 0.97629607}
-  m_LocalPosition: {x: 0.1849999, y: -0.037, z: 0.16099977}
-  m_LocalScale: {x: 0.12787864, y: 0.1334799, z: 0.45924842}
+  m_LocalRotation: {x: -0.25447425, y: -0, z: -0, w: 0.9670796}
+  m_LocalPosition: {x: 0.18499994, y: -0.048, z: -0.057}
+  m_LocalScale: {x: 0.12787864, y: 0.13347991, z: 0.45924848}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 9111951546681798067}
-  m_Father: {fileID: 2028740325759082492}
+  m_Father: {fileID: 677107268057318285}
   m_LocalEulerAnglesHint: {x: -25, y: 0, z: 0}
 --- !u!33 &8384225413980741234
 MeshFilter:
@@ -2806,8 +2808,6 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 3563727518308132522}
-  - {fileID: 8899145108802118775}
   - {fileID: 4164513468612024272}
   - {fileID: 4405254319491652169}
   - {fileID: 4164402288675975203}
@@ -2919,7 +2919,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 59a012f0b02de064294a28cd1cc7caf4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  grappling: 0
   walkSpeed: 7
   sprintSpeed: 15
   acceleration: 0.02
@@ -2930,7 +2929,6 @@ MonoBehaviour:
   groundMask:
     serializedVersion: 2
     m_Bits: 4294967295
-  currentSpeed: 0
   canMove: 1
   slideFrictionAdjustment: 0.2
   slideHeight: 0.5
@@ -2980,6 +2978,8 @@ MonoBehaviour:
   upThrust: 2.5
   releaseBoost: 2
   grappleIndicatorPrefab: {fileID: 6140398287122407268, guid: c235a6176978a1541a238729dbf6f4e2, type: 3}
+  maximumWindUp: 10
+  slingForce: 4
 --- !u!114 &6159800898551102946
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -3021,7 +3021,6 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 5231908350668840942}
-  - component: {fileID: 2703331760984556988}
   m_Layer: 0
   m_Name: B-spineProxy
   m_TagString: Untagged
@@ -3044,19 +3043,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 1372808272692084888}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &2703331760984556988
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8026314750805339795}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: dd95fd526fbaddd4e96feb1b5b051f7f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  originalSpine: {fileID: 4755193659365559529}
 --- !u!1 &8077050676753366214
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -6071,7 +6071,8 @@ Transform:
   m_LocalPosition: {x: -43.786926, y: -18.97106, z: 19.5}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children: []
+  m_Children:
+  - {fileID: 1125482267}
   m_Father: {fileID: 479455514}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!64 &792912245
@@ -7966,6 +7967,92 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1111339891}
   m_CullTransparentMesh: 1
+--- !u!1001 &1125482266
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 792912244}
+    m_Modifications:
+    - target: {fileID: 3433967378179982431, guid: 74796ed8de86dd24a940cdb51b0548ad, type: 3}
+      propertyPath: m_Name
+      value: GrappleAnchorPoint
+      objectReference: {fileID: 0}
+    - target: {fileID: 3617685950270364102, guid: 74796ed8de86dd24a940cdb51b0548ad, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 16.6
+      objectReference: {fileID: 0}
+    - target: {fileID: 3617685950270364102, guid: 74796ed8de86dd24a940cdb51b0548ad, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3617685950270364102, guid: 74796ed8de86dd24a940cdb51b0548ad, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3617685950270364102, guid: 74796ed8de86dd24a940cdb51b0548ad, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 3617685950270364102, guid: 74796ed8de86dd24a940cdb51b0548ad, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 3617685950270364102, guid: 74796ed8de86dd24a940cdb51b0548ad, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3617685950270364102, guid: 74796ed8de86dd24a940cdb51b0548ad, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3617685950270364102, guid: 74796ed8de86dd24a940cdb51b0548ad, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 90
+      objectReference: {fileID: 0}
+    - target: {fileID: 3617685950270364102, guid: 74796ed8de86dd24a940cdb51b0548ad, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3617685950270364102, guid: 74796ed8de86dd24a940cdb51b0548ad, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5100109744965799473, guid: 74796ed8de86dd24a940cdb51b0548ad, type: 3}
+      propertyPath: anchorType
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 5100109744965799473, guid: 74796ed8de86dd24a940cdb51b0548ad, type: 3}
+      propertyPath: planeSize.x
+      value: 90
+      objectReference: {fileID: 0}
+    - target: {fileID: 5100109744965799473, guid: 74796ed8de86dd24a940cdb51b0548ad, type: 3}
+      propertyPath: planeSize.y
+      value: 90
+      objectReference: {fileID: 0}
+    - target: {fileID: 5100109744965799473, guid: 74796ed8de86dd24a940cdb51b0548ad, type: 3}
+      propertyPath: boundingRadius
+      value: 63.63961
+      objectReference: {fileID: 0}
+    - target: {fileID: 5100109744965799473, guid: 74796ed8de86dd24a940cdb51b0548ad, type: 3}
+      propertyPath: planeResolution.x
+      value: 50
+      objectReference: {fileID: 0}
+    - target: {fileID: 5100109744965799473, guid: 74796ed8de86dd24a940cdb51b0548ad, type: 3}
+      propertyPath: planeResolution.y
+      value: 50
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 74796ed8de86dd24a940cdb51b0548ad, type: 3}
+--- !u!4 &1125482267 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3617685950270364102, guid: 74796ed8de86dd24a940cdb51b0548ad, type: 3}
+  m_PrefabInstance: {fileID: 1125482266}
+  m_PrefabAsset: {fileID: 0}
 --- !u!43 &1156244904
 Mesh:
   m_ObjectHideFlags: 0
@@ -18711,6 +18798,22 @@ PrefabInstance:
     - target: {fileID: 2028740325759082492, guid: afacc0513093d4fa3864912e11a13fb4, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2242431794466313390, guid: afacc0513093d4fa3864912e11a13fb4, type: 3}
+      propertyPath: slingForce
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 2242431794466313390, guid: afacc0513093d4fa3864912e11a13fb4, type: 3}
+      propertyPath: slingMinYDir
+      value: 0.7
+      objectReference: {fileID: 0}
+    - target: {fileID: 2242431794466313390, guid: afacc0513093d4fa3864912e11a13fb4, type: 3}
+      propertyPath: slingUpwardBoost
+      value: 0.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2242431794466313390, guid: afacc0513093d4fa3864912e11a13fb4, type: 3}
+      propertyPath: slingForwardBoost
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 8021186322358567283, guid: afacc0513093d4fa3864912e11a13fb4, type: 3}
       propertyPath: m_Name

--- a/Assets/Scripts/Player/PlayerMove.cs
+++ b/Assets/Scripts/Player/PlayerMove.cs
@@ -5,7 +5,8 @@ using UnityEngine;
 public class PlayerMove : MonoBehaviour
 {
     [Header("Movement Settings")]
-    public bool grappling = false;
+    public bool grappling { get;  set; }
+    public bool slingshotting { get; set; }
     public float walkSpeed = 7f;
     public float sprintSpeed = 12f;
     public float acceleration = 1f;
@@ -14,7 +15,7 @@ public class PlayerMove : MonoBehaviour
     public float airControl = 0.5f;
     public float groundCheckDistance = 0.5f;
     public LayerMask groundMask;
-    public float currentSpeed = 0;
+    public float currentSpeed { get;  set; }
     public bool canMove = true;
 
     [Header("Slide Settings")]
@@ -196,7 +197,7 @@ public class PlayerMove : MonoBehaviour
 
     void HandleMovement()
     {
-        if (grappling)
+        if (grappling && !slingshotting)
         {
             currentSpeed = Mathf.Min(rb.linearVelocity.magnitude, sprintSpeed);
             return;

--- a/Assets/Scripts/Player/Swinging.cs
+++ b/Assets/Scripts/Player/Swinging.cs
@@ -71,6 +71,9 @@ public class Swinging : MonoBehaviour
     [Header("Slingshot")]
     public float maximumWindUp;
     public float slingForce;
+    public float slingForwardBoost = 0.3f;
+    public float slingUpwardBoost = 0.25f;
+    public float slingMinYDir = 0.3f;
     private Vector3 initialPosition;
 
 
@@ -157,28 +160,31 @@ public class Swinging : MonoBehaviour
         dHeld = moveInput.x > 0.1f;
         spaceheld = inputState.JumpHeld;
 
-        
-        
+        Vector3 midPoint = Vector3.zero;
+        if (rightJoint != null && leftJoint != null) midPoint = (rightJoint.connectedAnchor + leftJoint.connectedAnchor) / 2;
+        else if (rightJoint != null) midPoint = rightJoint.connectedAnchor;
+        else if (leftJoint != null) midPoint = leftJoint.connectedAnchor;
+
         if (inputState.LeftSwingReleasedThisFrame)
         {
-            StopSwing(ref leftJoint, ref llr);
-            if (playermove.slingshotting)  playermove.slingshotting = false;
+            if (playermove.slingshotting) LaunchSlingShot(midPoint);
+            else StopSwing(ref leftJoint, ref llr);
+            
             if (inputState.RightSwingHeld) return;
             playermove.grappling = false;
         }
         if (inputState.RightSwingReleasedThisFrame)
         {
-            StopSwing(ref rightJoint, ref rlr);
-            if (playermove.slingshotting)  playermove.slingshotting = false;
+            if (playermove.slingshotting) LaunchSlingShot(midPoint);
+            else StopSwing(ref rightJoint, ref rlr);
+            
             if (inputState.LeftSwingHeld) return;
             playermove.grappling = false;
         }
 
         
         // If both grapples are active, the camera is looking towards the grapples, the player is on the ground and moving back do slingshot
-        Vector3 midPoint = Vector3.zero;
-        if (rightJoint != null && leftJoint != null)  midPoint = (rightJoint.connectedAnchor + leftJoint.connectedAnchor)/2;
-        if(Vector3.Dot(cam.forward.normalized, (midPoint - cam.position).normalized) > 0.9 && playermove.grounded && sHeld)
+        if(rightJoint != null && leftJoint != null && Vector3.Dot(cam.forward.normalized, (midPoint - cam.position).normalized) > 0.9 && playermove.grounded && sHeld)
         {
             if(!playermove.slingshotting)
             {
@@ -231,7 +237,8 @@ public class Swinging : MonoBehaviour
         }
         
         Vector3 direction = (midPoint - transform.position).normalized;
-        direction = (direction + cam.forward * 0.3f + Vector3.up * 0.25f).normalized;
+        if (direction.y < slingMinYDir) direction.y = slingMinYDir; // Prevent launching into the ground
+        direction = (direction + cam.forward * slingForwardBoost + Vector3.up * slingUpwardBoost).normalized;
         Vector3 force = direction * (transform.position - initialPosition).magnitude;
         rb.AddForce(force * slingForce, ForceMode.Impulse);
     }

--- a/Assets/Scripts/Player/Swinging.cs
+++ b/Assets/Scripts/Player/Swinging.cs
@@ -39,7 +39,6 @@ public class Swinging : MonoBehaviour
     private float maxSwingDistance = 25f;
     private Vector3 leftSwingPoint;
     private Vector3 rightSwingPoint;
-    private Vector3 avgSwingPoint;
     private SpringJoint leftJoint;
     private SpringJoint rightJoint;
     public float maxSpeed;
@@ -68,6 +67,12 @@ public class Swinging : MonoBehaviour
     public GameObject grappleIndicatorPrefab;
     private GameObject grappleIndicatorInstanceRed;
     private GameObject grappleIndicatorInstanceBlue;
+
+    [Header("Slingshot")]
+    public float maximumWindUp;
+    public float slingForce;
+    private Vector3 initialPosition;
+
 
     void Awake()
     {
@@ -133,37 +138,102 @@ public class Swinging : MonoBehaviour
 
        
 
-            if (inputState.LeftSwingPressedThisFrame)
+        if (inputState.LeftSwingPressedThisFrame)
         {
             StartSwing(currentTargetPointLeft, ref leftJoint, leftGunTip, ref llr);
             playermove.grappling = true;
             leftSwingPoint = currentTargetPointLeft;
         }
-            if (inputState.RightSwingPressedThisFrame)
+        if (inputState.RightSwingPressedThisFrame)
         {
             StartSwing(currentTargetPointRight, ref rightJoint, rightGunTip, ref rlr);
             playermove.grappling = true;
             rightSwingPoint = currentTargetPointRight;
         }
-            wHeld = moveInput.y > 0.1f;
-            aHeld = moveInput.x < -0.1f;
-            sHeld = moveInput.y < -0.1f;
-            dHeld = moveInput.x > 0.1f;
-            spaceheld = inputState.JumpHeld;
 
-            if (inputState.LeftSwingReleasedThisFrame)
+        wHeld = moveInput.y > 0.1f;
+        aHeld = moveInput.x < -0.1f;
+        sHeld = moveInput.y < -0.1f;
+        dHeld = moveInput.x > 0.1f;
+        spaceheld = inputState.JumpHeld;
+
+        
+        
+        if (inputState.LeftSwingReleasedThisFrame)
         {
             StopSwing(ref leftJoint, ref llr);
-                if (inputState.RightSwingHeld) return;
+            if (playermove.slingshotting)  playermove.slingshotting = false;
+            if (inputState.RightSwingHeld) return;
             playermove.grappling = false;
         }
-            if (inputState.RightSwingReleasedThisFrame)
+        if (inputState.RightSwingReleasedThisFrame)
         {
             StopSwing(ref rightJoint, ref rlr);
-                if (inputState.LeftSwingHeld) return;
+            if (playermove.slingshotting)  playermove.slingshotting = false;
+            if (inputState.LeftSwingHeld) return;
             playermove.grappling = false;
         }
 
+        
+        // If both grapples are active, the camera is looking towards the grapples, the player is on the ground and moving back do slingshot
+        Vector3 midPoint = Vector3.zero;
+        if (rightJoint != null && leftJoint != null)  midPoint = (rightJoint.connectedAnchor + leftJoint.connectedAnchor)/2;
+        if(Vector3.Dot(cam.forward.normalized, (midPoint - cam.position).normalized) > 0.9 && playermove.grounded && sHeld)
+        {
+            if(!playermove.slingshotting)
+            {
+                StartSlingshot();
+            }
+        }
+        if (playermove.slingshotting)
+        {
+            float distance = (transform.position - initialPosition).magnitude;
+            float windUpSpeed = Mathf.Max(maximumWindUp - distance, 0);
+            playermove.currentSpeed = Mathf.Min(windUpSpeed, playermove.currentSpeed);
+
+            if((midPoint - transform.position - (midPoint - initialPosition)).sqrMagnitude >  + maximumWindUp*maximumWindUp + 5)
+            {
+                LaunchSlingShot(midPoint);
+            }
+        }
+
+        if (moveInput.y >= 0  && playermove.slingshotting)
+        {
+           LaunchSlingShot(midPoint);
+        }
+    }
+
+    void StartSlingshot()
+    {
+        playermove.slingshotting = true;
+        initialPosition = transform.position;
+        leftJoint.spring = 0;
+        leftJoint.damper = 0;
+        rightJoint.spring = 0;
+        rightJoint.damper = 0;
+    }
+
+    void LaunchSlingShot(Vector3 midPoint)
+    {
+        playermove.slingshotting = false;
+        
+        if(rightJoint != null)
+        {
+            Destroy(rightJoint);
+            rightJoint = null;
+            rlr.positionCount = 0;
+        }
+        if (leftJoint != null)
+        {
+            Destroy(leftJoint);
+            leftJoint = null;
+            llr.positionCount = 0;
+        }
+        
+        Vector3 direction = (midPoint - transform.position).normalized;
+        direction = (direction + cam.forward * 0.3f + Vector3.up * 0.25f).normalized;
+        Vector3 force = direction * (transform.position - initialPosition).magnitude;
+        rb.AddForce(force * slingForce, ForceMode.Impulse);
     }
 
     void OnDrawGizmos()
@@ -199,9 +269,6 @@ public class Swinging : MonoBehaviour
 
         if (rightJoint == null && leftJoint == null) return;
 
-        if (leftJoint != null && rightJoint != null) avgSwingPoint = (leftSwingPoint + rightSwingPoint) / 2f;
-        else if (leftJoint != null) avgSwingPoint = leftSwingPoint;
-        else if (rightJoint != null) avgSwingPoint = rightSwingPoint;
 
         if (leftJoint != null)
         {


### PR DESCRIPTION
## What are the changes?
Added slingshot ability.
When on the ground, both grapples are engaged, and looking generally towards the midpoint between the anchors, holding s enters slingshot mode.
In slingshot mode the grapple joints apply zero force, allowing the player to move, and as the player moves further back, reduces their speed based on the maximum wind up. Then when either s is released, or the player moves away from the midpoint/midpoint away from the player (e.g. falling off a platform, grappled onto a moving target (when implemented)), deletes the grapple joints and adds a force based on the distance the player moved since entering slingshot mode.
Disengaging either grapple cancels slingshot mode without launching.

## How can the changes be tested?
On the ground, while both grapples are out and looking at them, holding s should allow movement, which slows down, and then adds a reasonable force in the direction of the anchors upon release.

## Any issues or bugs with the changes?
Before this the only way to gain speed was with the grapples, but now that this can go faster than grappling, it revealed that when grappling, it reduces your momentum, yay more problems with conserving speed in the air.

## Screenshots of changes (if applicable)
