### PR TITLE
Scoring

### DIFF
--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -9140,7 +9140,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::LevelManager
   gameTimer: {fileID: 912977857}
-  uiManager: {fileID: 932442583}
   startingRoomPrefab: {fileID: 4282723140107944820, guid: 99f2feed0e46e445aad004e423d5d629, type: 3}
   parkourRoomPrefabs:
   - {fileID: 4282723140107944820, guid: 99f2feed0e46e445aad004e423d5d629, type: 3}
@@ -9250,6 +9249,7 @@ RectTransform:
   - {fileID: 1285678752}
   - {fileID: 765898808}
   - {fileID: 1791977428}
+  - {fileID: 1904516047}
   - {fileID: 2102495867}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -13016,6 +13016,143 @@ MonoBehaviour:
   m_Damping: 0
   m_DampingWhenOccluded: 0
   m_OptimalTargetDistance: 0
+--- !u!1 &1904516046
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1904516047}
+  - component: {fileID: 1904516049}
+  - component: {fileID: 1904516048}
+  m_Layer: 5
+  m_Name: Levels Text (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1904516047
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1904516046}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 932442582}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 213, y: -40}
+  m_SizeDelta: {x: 400, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1904516048
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1904516046}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 'Score: '
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 36
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_characterHorizontalScale: 1
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &1904516049
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1904516046}
+  m_CullTransparentMesh: 1
 --- !u!1 &1933639026
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -9272,6 +9272,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::UIManager
   timeSlider: {fileID: 765898809}
   levelsBeatenText: {fileID: 1791977429}
+  scoreText: {fileID: 1904516048}
+  gameOverDetails: {fileID: 954558456}
   gameOverPanel: {fileID: 2102495866}
 --- !u!1 &954558454
 GameObject:
@@ -9307,7 +9309,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: -100}
+  m_AnchoredPosition: {x: 5.1, y: -136}
   m_SizeDelta: {x: 750, y: 200}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &954558456
@@ -9332,7 +9334,12 @@ MonoBehaviour:
       m_Calls: []
   m_text: 'Out of time!
 
-    Press R to restart'
+    Final Score: 1402
+
+    Press R to restart
+
+    Edit
+    in UI manager'
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
@@ -10891,7 +10898,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &1285678752
 RectTransform:
   m_ObjectHideFlags: 0
@@ -13028,7 +13035,7 @@ GameObject:
   - component: {fileID: 1904516049}
   - component: {fileID: 1904516048}
   m_Layer: 5
-  m_Name: Levels Text (1)
+  m_Name: Score Text
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0

--- a/Assets/Scripts/Systems/Levels/GameTimer.cs
+++ b/Assets/Scripts/Systems/Levels/GameTimer.cs
@@ -8,6 +8,7 @@ public class GameTimer : MonoBehaviour
     public UIManager uiManager;
 
     private float currentTime;
+    private float decayMultiplier;
     private float maxTimeForCurrentLevel;
     private bool isTimerRunning = false;
 
@@ -51,7 +52,7 @@ public class GameTimer : MonoBehaviour
         }
 
         // Calculate the decayed time: defaultTime / (decayRate ^ timesCompleted)
-        float decayMultiplier = Mathf.Pow(level.decayRate, timesCompleted);
+        decayMultiplier = Mathf.Pow(level.decayRate, timesCompleted);
         maxTimeForCurrentLevel = level.defaultTime / decayMultiplier;
         
         currentTime = maxTimeForCurrentLevel;
@@ -75,16 +76,16 @@ public class GameTimer : MonoBehaviour
             roomCompletionCounts.Add(level.levelID, 1);
         }
 
-        score += Mathf.RoundToInt(100 * currentTime/maxTimeForCurrentLevel);
-
+        score += Mathf.RoundToInt(100 * currentTime/maxTimeForCurrentLevel * decayMultiplier);
         uiManager.UpdateLevelsBeatenDisplay(roomCompletionCounts.Values.Sum());
         uiManager.UpdateScoreDisplay(score);
+
     }
 
     private void TriggerGameOver()
     {
         isTimerRunning = false;
-        uiManager.ShowGameOverScreen();
+        uiManager.ShowGameOverScreen(score);
         
         // Add your logic here to freeze the player or stop game time
         Time.timeScale = 0f;

--- a/Assets/Scripts/Systems/Levels/GameTimer.cs
+++ b/Assets/Scripts/Systems/Levels/GameTimer.cs
@@ -14,6 +14,8 @@ public class GameTimer : MonoBehaviour
     // Dictionary to track how many times the player has completed specific rooms
     private Dictionary<string, int> roomCompletionCounts = new Dictionary<string, int>();
 
+    private int score;
+
     private void Update()
     {
         if (!isTimerRunning) return;
@@ -73,7 +75,10 @@ public class GameTimer : MonoBehaviour
             roomCompletionCounts.Add(level.levelID, 1);
         }
 
+        score += Mathf.RoundToInt(100 * currentTime/maxTimeForCurrentLevel);
+
         uiManager.UpdateLevelsBeatenDisplay(roomCompletionCounts.Values.Sum());
+        uiManager.UpdateScoreDisplay(score);
     }
 
     private void TriggerGameOver()

--- a/Assets/Scripts/Systems/Levels/GameTimer.cs
+++ b/Assets/Scripts/Systems/Levels/GameTimer.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using UnityEngine;
+using System.Linq;
 
 public class GameTimer : MonoBehaviour
 {
@@ -71,6 +72,8 @@ public class GameTimer : MonoBehaviour
         {
             roomCompletionCounts.Add(level.levelID, 1);
         }
+
+        uiManager.UpdateLevelsBeatenDisplay(roomCompletionCounts.Values.Sum());
     }
 
     private void TriggerGameOver()

--- a/Assets/Scripts/Systems/Levels/LevelManager.cs
+++ b/Assets/Scripts/Systems/Levels/LevelManager.cs
@@ -5,7 +5,6 @@ public class LevelManager : MonoBehaviour
 {
     [Header("System References")]
     public GameTimer gameTimer;
-    public UIManager uiManager;
 
     [Header("Prefabs")]
     public Level startingRoomPrefab;
@@ -92,7 +91,6 @@ public class LevelManager : MonoBehaviour
         // 3. ONLY spawn the next sequence if we just beat a main parkour room
         if (!completedRoom.isHallway)
         {
-            uiManager.IncrementLevelsBeaten();
             SpawnNextSequence();
         }
 

--- a/Assets/Scripts/UI/UIManager.cs
+++ b/Assets/Scripts/UI/UIManager.cs
@@ -7,6 +7,7 @@ public class UIManager : MonoBehaviour
     [Header("UI Elements")]
     public Slider timeSlider;
     public TMP_Text levelsBeatenText;
+    public TMP_Text scoreText;
     public GameObject gameOverPanel;
 
 
@@ -42,6 +43,14 @@ public class UIManager : MonoBehaviour
         if (levelsBeatenText != null)
         {
             levelsBeatenText.text = "Levels Cleared: " + totalLevelsBeaten.ToString();
+        }
+    }
+
+    public void UpdateScoreDisplay(int score)
+    {
+        if (scoreText != null)
+        {
+            scoreText.text = "Score: " + score.ToString();
         }
     }
 

--- a/Assets/Scripts/UI/UIManager.cs
+++ b/Assets/Scripts/UI/UIManager.cs
@@ -8,6 +8,7 @@ public class UIManager : MonoBehaviour
     public Slider timeSlider;
     public TMP_Text levelsBeatenText;
     public TMP_Text scoreText;
+    public TMP_Text gameOverDetails;
     public GameObject gameOverPanel;
 
 
@@ -20,6 +21,7 @@ public class UIManager : MonoBehaviour
         }
         
         UpdateLevelsBeatenDisplay(0);
+        UpdateScoreDisplay(0);
     }
 
     /// <summary>
@@ -35,7 +37,7 @@ public class UIManager : MonoBehaviour
     }
 
     /// <summary>
-    /// Increments and updates the global score. Called by GameTimer.
+    /// Updates the levels beaten display. Called by GameTimer.
     /// </summary>
 
     public void UpdateLevelsBeatenDisplay(int totalLevelsBeaten)
@@ -54,10 +56,11 @@ public class UIManager : MonoBehaviour
         }
     }
 
-    public void ShowGameOverScreen()
+    public void ShowGameOverScreen(int score)
     {
         if (gameOverPanel != null)
         {
+            gameOverDetails.text = "Out of time!\nFinal Score: " + score.ToString() + "\nPress R to restart";
             gameOverPanel.SetActive(true);
         }
     }

--- a/Assets/Scripts/UI/UIManager.cs
+++ b/Assets/Scripts/UI/UIManager.cs
@@ -9,7 +9,6 @@ public class UIManager : MonoBehaviour
     public TMP_Text levelsBeatenText;
     public GameObject gameOverPanel;
 
-    private int totalLevelsBeaten = 0;
 
     private void Start()
     {
@@ -19,7 +18,7 @@ public class UIManager : MonoBehaviour
             gameOverPanel.SetActive(false);
         }
         
-        UpdateLevelsBeatenDisplay();
+        UpdateLevelsBeatenDisplay(0);
     }
 
     /// <summary>
@@ -35,15 +34,10 @@ public class UIManager : MonoBehaviour
     }
 
     /// <summary>
-    /// Increments and updates the global score. Called by LevelManager or GameTimer.
+    /// Increments and updates the global score. Called by GameTimer.
     /// </summary>
-    public void IncrementLevelsBeaten()
-    {
-        totalLevelsBeaten++;
-        UpdateLevelsBeatenDisplay();
-    }
 
-    private void UpdateLevelsBeatenDisplay()
+    public void UpdateLevelsBeatenDisplay(int totalLevelsBeaten)
     {
         if (levelsBeatenText != null)
         {


### PR DESCRIPTION
## What are the changes?
Refactored levels beaten UI, before UI manager stored levels beaten and got updated by level manager telling it to increment, as well as level manager also telling game timer to record level completion too.
I removed UI manager storing levels beaten given game timer was also doing it as well basically, and with level manager calling game timer to record level completion, also made game timer call UI manager to update and gave it new levels beaten value, which could remove level manager's reference to UI manager.

Added scoring, given its reliance on game time I put it in game timer, where in record level completion it added the percentage to remaining time multiplied by the decay multiplier to the score and called UI manager to update the score text
Added final score to game over screen and hence UI manager edits the details section of it

## How can the changes be tested?
Look at the score when completing a level, it should increase more with more time remaining

## Any issues or bugs with the changes?
It records the starting room as a level and adds it to levels beaten and score, now this could be correct and intended, just mentioning it incase it's not

## Screenshots of changes (if applicable)
<img width="2038" height="908" alt="image" src="https://github.com/user-attachments/assets/64022ad2-9a99-46dc-b425-d822ac14f896" />

